### PR TITLE
Return only a single instance when the single search param is set

### DIFF
--- a/tornado_restless/handler.py
+++ b/tornado_restless/handler.py
@@ -758,7 +758,7 @@ class BaseHandler(RequestHandler):
             return {'num_results': num_results,
                     "total_pages": total_pages,
                     "page": page + 1,
-                    "objects": instances}
+                    "objects": self.to_dict(instances)}
 
     def _call_preprocessor(self, *args, **kwargs):
         """


### PR DESCRIPTION
According to the flask-restless docs, if you include `"single": true` in the search query, the API should only return a single object, not the full list response. This PR changes the library to have that functionality.

http://flask-restless.readthedocs.org/en/latest/searchformat.html#expecting-a-single-result
