### PR TITLE
set op to 'eq' for relation filters

### DIFF
--- a/tests/test_get.py
+++ b/tests/test_get.py
@@ -148,3 +148,22 @@ class TestGet(TestBase):
         """
 
         self.curl_tornado('/api/persons/1337', assert_for=400)
+
+    def test_relation(self):
+        params = {
+            'q': json.dumps({'filters': [{'name': 'cities._city', 'op': 'any', 'val': 60400}]})
+        }
+        tornado_data = self.curl_tornado('/api/persons', params=params)
+        assert len(tornado_data['objects']) == 2
+
+        params = {
+            'q': json.dumps({'filters': [{'name': 'cities._city', 'op': 'any', 'val': 10800}]})
+        }
+        tornado_data = self.curl_tornado('/api/persons', params=params)
+        assert len(tornado_data['objects']) == 1
+
+        params = {
+            'q': json.dumps({'filters': [{'name': 'cities._city', 'op': 'any', 'val': 123}]})
+        }
+        tornado_data = self.curl_tornado('/api/persons', params=params)
+        assert len(tornado_data['objects']) == 0

--- a/tornado_restless/convert.py
+++ b/tornado_restless/convert.py
@@ -74,6 +74,7 @@ def to_filter(instance,
             left = getattr(instance, relation)
             op = "has"
             argument_filter["name"] = name
+            argument_filter["op"] = "eq"
             right = to_filter(instance=left.property.mapper.class_, filters=[argument_filter])
         elif argument_filter["name"] == "~":
             left = instance


### PR DESCRIPTION
I couldn't get relationship filters to work at all, so to make queries work as per the flask-restless docs here: 
http://flask-restless.readthedocs.org/en/latest/searchformat.html#comparing-attribute-of-a-relation
the `to_filter` method needs to set the argument_filter `op` to `"eq"`

I've added test cases to ensure the functionality works.