### PR TITLE
In "handler.py" self.finish() get called twice and raises an exception

### DIFF
--- a/tornado_restless/handler.py
+++ b/tornado_restless/handler.py
@@ -244,7 +244,8 @@ class BaseHandler(RequestHandler):
             result = self.patch_single(self.parse_pk(instance_id))
 
         self._call_postprocessor(result=result)
-        self.finish(result)
+        if not self._finished:
+            self.finish(result)
 
     def patch_many(self) -> dict:
         """
@@ -364,7 +365,8 @@ class BaseHandler(RequestHandler):
             result = self.delete_single(self.parse_pk(instance_id))
 
         self._call_postprocessor(result=result)
-        self.finish(result)
+        if not self._finished:
+            self.finish(result)
 
     def delete_many(self) -> dict:
         """
@@ -455,7 +457,8 @@ class BaseHandler(RequestHandler):
             result = self.put_single(self.parse_pk(instance_id))
 
         self._call_postprocessor(result=result)
-        self.finish(result)
+        if not self._finished:
+            self.finish(result)
 
     put_many = patch_many
     put_single = patch_single
@@ -480,7 +483,8 @@ class BaseHandler(RequestHandler):
         result = self.post_single()
 
         self._call_postprocessor(result=result)
-        self.finish(result)
+        if not self._finished:
+            self.finish(result)
 
     def post_single(self):
         """
@@ -691,7 +695,8 @@ class BaseHandler(RequestHandler):
             result = self.get_single(self.parse_pk(instance_id))
 
         self._call_postprocessor(result=result)
-        self.finish(result)
+        if not self._finished:
+            self.finish(result)
 
     def get_single(self, instance_id: list) -> dict:
         """


### PR DESCRIPTION
Every time a request interacts with the DB via SQLAlchemy and causes an error (e.g. breaking a unique constraint, non-existent column, etc), a RuntimeError is raised by Tornado because the self.finish() method is called twice in Tornado Restless.

This patch assures that in the "patch", "delete", "put", "post", "get" methods call "self.finish(result)" only once.

You can find a detailed description of the causes in tornado-utils#10