### PR TITLE
Making the library compatible with 2.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,9 @@
 # C extensions
 *.so
 
+
 # Packages
+env
 *.egg
 *.egg-info
 dist

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 sqlalchemy>0.8
 tornado>=3.1
+future

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     name='Tornado-Restless27',
     version=__version__,
     author='James Westover',
-    author_email='martin@martimeo.de',
+    author_email='westover@pas.rochester.edu',
     url='https://github.com/westover/tornado-restless',
     packages=['tornado_restless'],
     license='GNU AGPLv3+ or BSD-3-clause',

--- a/setup.py
+++ b/setup.py
@@ -8,11 +8,11 @@ from setuptools import setup
 from tornado_restless import __version__
 
 setup(
-    name='Tornado-Restless27',
+    name='Tornado-Restless',
     version=__version__,
-    author='James Westover',
-    author_email='westover@pas.rochester.edu',
-    url='https://github.com/westover/tornado-restless',
+    author='Martin Martimeo',
+    author_email='martin@martimeo.de',
+    url='https://github.com/tornado-utils/tornado-restless',
     packages=['tornado_restless'],
     license='GNU AGPLv3+ or BSD-3-clause',
     platforms='any',
@@ -31,6 +31,8 @@ setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.3',
         'Topic :: Software Development :: Libraries :: Python Modules'
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -3,18 +3,16 @@
 """
 
 """
-__author__ = 'Martin Martimeo <martin@martimeo.de>'
-__date__ = '29.04.13 - 15:34'
-
+from __future__ import unicode_literals, print_function
 from setuptools import setup
 from tornado_restless import __version__
 
 setup(
-    name='Tornado-Restless',
+    name='Tornado-Restless27',
     version=__version__,
-    author='Martin Martimeo',
+    author='James Westover',
     author_email='martin@martimeo.de',
-    url='https://github.com/tornado-utils/tornado-restless',
+    url='https://github.com/westover/tornado-restless',
     packages=['tornado_restless'],
     license='GNU AGPLv3+ or BSD-3-clause',
     platforms='any',
@@ -31,8 +29,8 @@ setup(
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
         'Topic :: Software Development :: Libraries :: Python Modules'
     ],
 )

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -6,6 +6,3 @@
 
     Tests the implementation against the 'official' `flask-restless` api
 """
-
-__author__ = 'Martin Martimeo <martin@martimeo.de>'
-__date__ = '21.08.13'

--- a/tests/base.py
+++ b/tests/base.py
@@ -7,7 +7,10 @@ from datetime import datetime
 from json import loads
 import logging
 from threading import Thread
-from urllib.parse import urljoin
+try:
+    from urllib.parse import urljoin
+except ImportError:
+    from future.moves.urllib.parse import urljoin
 import os
 
 from flask import Flask

--- a/tests/base.py
+++ b/tests/base.py
@@ -3,6 +3,7 @@
 """
     
 """
+from __future__ import unicode_literals
 from datetime import datetime
 from json import loads
 import logging
@@ -24,10 +25,6 @@ import tornado.ioloop
 from flask.ext.restless import APIManager as FlaskRestlessManager
 
 from tornado_restless import ApiManager as TornadoRestlessManager
-
-
-__author__ = 'Martin Martimeo <martin@martimeo.de>'
-__date__ = '21.08.13'
 
 
 class TestBase(object):

--- a/tests/test_get.py
+++ b/tests/test_get.py
@@ -3,6 +3,7 @@
 """
     
 """
+from __future__ import unicode_literals
 import json
 import logging
 from .base import TestBase

--- a/tests/test_get.py
+++ b/tests/test_get.py
@@ -7,9 +7,6 @@ import json
 import logging
 from .base import TestBase
 
-__author__ = 'Martin Martimeo <martin@martimeo.de>'
-__date__ = '21.08.13'
-
 
 class TestGet(TestBase):
     """

--- a/tests/test_post.py
+++ b/tests/test_post.py
@@ -3,6 +3,7 @@
 """
 
 """
+from __future__ import unicode_literals
 import json
 from tests.base import TestBase
 

--- a/tests/test_post.py
+++ b/tests/test_post.py
@@ -6,9 +6,6 @@
 import json
 from tests.base import TestBase
 
-__author__ = 'Martin Martimeo <martin@martimeo.de>'
-__date__ = '04.09.13 - 16:14'
-
 
 class TestGet(TestBase):
     """

--- a/tornado_restless/__init__.py
+++ b/tornado_restless/__init__.py
@@ -3,10 +3,7 @@
 """
 
 """
-__author__ = 'Martin Martimeo <martin@martimeo.de>'
-__date__ = '29.04.13 - 15:37'
-
 from .api import ApiManager
 
 __all__ = ['ApiManager']
-__version__ = '0.4.5'
+__version__ = '0.1.0'

--- a/tornado_restless/__init__.py
+++ b/tornado_restless/__init__.py
@@ -6,4 +6,4 @@
 from .api import ApiManager
 
 __all__ = ['ApiManager']
-__version__ = '0.1.0'
+__version__ = '0.4.6'

--- a/tornado_restless/api.py
+++ b/tornado_restless/api.py
@@ -3,13 +3,12 @@
 """
 
 """
-from tornado.web import Application, URLSpec
+from __future__ import absolute_import, print_function, unicode_literals
+
+from tornado.web import URLSpec
 
 from .handler import BaseHandler
 from .errors import IllegalArgumentError
-
-__author__ = 'Martin Martimeo <martin@martimeo.de>'
-__date__ = '26.04.13 - 22:25'
 
 
 class ApiManager(object):
@@ -26,9 +25,7 @@ class ApiManager(object):
     METHODS_UPDATE = METHODS_READ | METHODS_MODIFY
     METHODS_ALL = METHODS_READ | METHODS_MODIFY | METHODS_DELETE
 
-    def __init__(self,
-                 application: Application,
-                 session_maker: type=None):
+    def __init__(self, application, session_maker):
         """
         Create an instance of the tornado restless engine
 
@@ -41,22 +38,22 @@ class ApiManager(object):
 
     def create_api_blueprint(self,
                              model,
-                             methods: set=METHODS_READ,
-                             preprocessor: dict=None,
-                             postprocessor: dict=None,
-                             url_prefix: str='/api',
-                             collection_name: str=None,
-                             allow_patch_many: bool=False,
-                             allow_method_override: bool=False,
+                             methods=METHODS_READ,
+                             preprocessor=None,
+                             postprocessor=None,
+                             url_prefix='/api',
+                             collection_name=None,
+                             allow_patch_many=False,
+                             allow_method_override=False,
                              validation_exceptions=None,
-                             exclude_queries: bool=False,
-                             exclude_hybrids: bool=False,
-                             include_columns: list=None,
-                             exclude_columns: list=None,
-                             results_per_page: int=10,
-                             max_results_per_page: int=100,
-                             blueprint_prefix: str='',
-                             handler_class: type=BaseHandler) -> URLSpec:
+                             exclude_queries=False,
+                             exclude_hybrids=False,
+                             include_columns=None,
+                             exclude_columns=None,
+                             results_per_page=10,
+                             max_results_per_page=100,
+                             blueprint_prefix='',
+                             handler_class=BaseHandler):
         """
         Create a tornado route for a sqlalchemy model
 

--- a/tornado_restless/convert.py
+++ b/tornado_restless/convert.py
@@ -3,6 +3,7 @@
 """
 
 """
+from __future__ import unicode_literals, print_function, absolute_import
 from datetime import datetime, date, time
 from decimal import Decimal
 import collections
@@ -15,9 +16,6 @@ from sqlalchemy.orm.query import Query
 from .errors import IllegalArgumentError, DictConvertionError
 from .wrapper import ModelWrapper
 
-
-__author__ = 'Martin Martimeo <martin@martimeo.de>'
-__date__ = '23.05.13 - 17:41'
 
 __datetypes__ = (datetime, time, date)
 __basetypes__ = (str, int, bool, float)

--- a/tornado_restless/errors.py
+++ b/tornado_restless/errors.py
@@ -3,8 +3,6 @@
 """
 
 """
-__author__ = 'Martin Martimeo <martin@martimeo.de>'
-__date__ = '22.08.13 - 17:44'
 
 from tornado.web import HTTPError
 
@@ -36,7 +34,7 @@ class DictConvertionError(HTTPError):
     """
 
     def __init__(self, instance_type, log_message=None, status_code=400, *args, **kwargs):
-        super().__init__(status_code, log_message, *args, **kwargs)
+        super(DictConvertionError, self).__init__(status_code, log_message, *args, **kwargs)
         self.instance_type = instance_type
 
 
@@ -52,5 +50,5 @@ except ImportError:
         """
 
         def __init__(self, method=None, log_message=None, status_code=405, *args, **kwargs):
-            super().__init__(status_code, log_message, *args, **kwargs)
+            super(MethodNotAllowedError, self).__init__(status_code, log_message, *args, **kwargs)
             self.method = method

--- a/tornado_restless/errors.py
+++ b/tornado_restless/errors.py
@@ -3,8 +3,9 @@
 """
 
 """
-
+from __future__ import unicode_literals
 from tornado.web import HTTPError
+from builtins import super
 
 
 class IllegalArgumentError(ValueError, HTTPError):
@@ -34,7 +35,7 @@ class DictConvertionError(HTTPError):
     """
 
     def __init__(self, instance_type, log_message=None, status_code=400, *args, **kwargs):
-        super(DictConvertionError, self).__init__(status_code, log_message, *args, **kwargs)
+        super().__init__(status_code, log_message, *args, **kwargs)
         self.instance_type = instance_type
 
 
@@ -50,5 +51,5 @@ except ImportError:
         """
 
         def __init__(self, method=None, log_message=None, status_code=405, *args, **kwargs):
-            super(MethodNotAllowedError, self).__init__(status_code, log_message, *args, **kwargs)
+            super().__init__(status_code, log_message, *args, **kwargs)
             self.method = method

--- a/tornado_restless/handler.py
+++ b/tornado_restless/handler.py
@@ -245,7 +245,8 @@ class BaseHandler(RequestHandler):
             result = self.patch_single(self.parse_pk(instance_id))
 
         self._call_postprocessor(result=result)
-        self.finish(result)
+        if not self._finished:
+            self.finish(result)
 
     def patch_many(self):
         """
@@ -365,7 +366,8 @@ class BaseHandler(RequestHandler):
             result = self.delete_single(self.parse_pk(instance_id))
 
         self._call_postprocessor(result=result)
-        self.finish(result)
+        if not self._finished:
+            self.finish(result)
 
     def delete_many(self):
         """
@@ -456,7 +458,8 @@ class BaseHandler(RequestHandler):
             result = self.put_single(self.parse_pk(instance_id))
 
         self._call_postprocessor(result=result)
-        self.finish(result)
+        if not self._finished:
+            self.finish(result)
 
     put_many = patch_many
     put_single = patch_single
@@ -692,7 +695,8 @@ class BaseHandler(RequestHandler):
             result = self.get_single(self.parse_pk(instance_id))
 
         self._call_postprocessor(result=result)
-        self.finish(result)
+        if not self._finished:
+            self.finish(result)
 
     def get_single(self, instance_id):
         """

--- a/tornado_restless/handler.py
+++ b/tornado_restless/handler.py
@@ -18,6 +18,8 @@ except ImportError:
 import sys
 import itertools
 
+from builtins import super
+
 from sqlalchemy import inspect as sqinspect
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm.exc import NoResultFound, UnmappedInstanceError, MultipleResultsFound
@@ -90,7 +92,7 @@ class BaseHandler(RequestHandler):
         if allow_method_override and 'X-HTTP-Method-Override' in self.request.headers:
             self.request.method = self.request.headers['X-HTTP-Method-Override']
 
-        super(BaseHandler, self).initialize()
+        super().initialize()
 
         self.model = SessionedModelWrapper(model, manager.session_maker())
         self.pk_length = len(sqinspect(model).primary_key)
@@ -214,9 +216,9 @@ class BaseHandler(RequestHandler):
                 self.finish(dict(type=exc_type.__module__ + "." + exc_type.__name__,
                                  message="%s" % exc_value, **exc_value.__dict__))
             else:
-                super(BaseHandler,self).write_error(status_code, **kwargs)
+                super().write_error(status_code, **kwargs)
         else:
-            super(BaseHandler, self).write_error(status_code, **kwargs)
+            super().write_error(status_code, **kwargs)
 
     def patch(self, instance_id=None):
         """
@@ -612,7 +614,7 @@ class BaseHandler(RequestHandler):
             :param kwargs: Additional keyword arguments @see tornado.web.RequestHandler.get_argument
         """
         try:
-            return super(BaseHandler, self).get_argument(name, *args, **kwargs)
+            return super().get_argument(name, *args, **kwargs)
         except HTTPError:
             if name == "q" and self.request.method in ['PUT', 'PATCH']:
                 return self.get_body_argument(name, *args, **kwargs)

--- a/tornado_restless/wrapper.py
+++ b/tornado_restless/wrapper.py
@@ -3,9 +3,13 @@
 """
 
 """
+from __future__ import unicode_literals
 from collections import namedtuple
 import inspect
 import logging
+
+from builtins import super
+
 
 from sqlalchemy import inspect as sqinspect
 from sqlalchemy.exc import NoInspectionAvailable
@@ -256,7 +260,7 @@ class SessionedModelWrapper(ModelWrapper):
     """
 
     def __init__(self, model, session):
-        super(SessionedModelWrapper, self).__init__(model)
+        super().__init__(model)
         self.session = session
 
     @staticmethod

--- a/tornado_restless/wrapper.py
+++ b/tornado_restless/wrapper.py
@@ -11,7 +11,7 @@ from sqlalchemy import inspect as sqinspect
 from sqlalchemy.exc import NoInspectionAvailable
 from sqlalchemy.ext.associationproxy import AssociationProxy
 from sqlalchemy.ext.hybrid import hybrid_property
-from sqlalchemy.orm import ColumnProperty, Query
+from sqlalchemy.orm import ColumnProperty
 from sqlalchemy.orm.attributes import QueryableAttribute
 from sqlalchemy.orm.exc import NoResultFound
 from sqlalchemy.orm.interfaces import MapperProperty
@@ -20,11 +20,7 @@ from sqlalchemy.sql.operators import is_ordering_modifier
 from sqlalchemy.util import memoized_property
 
 
-__author__ = 'Martin Martimeo <martin@martimeo.de>'
-__date__ = '27.04.13 - 00:14'
-
-
-def _filter(instance, condition) -> dict:
+def _filter(instance, condition):
     """
         Filter properties of instace based on condition
 
@@ -94,7 +90,7 @@ class ModelWrapper(object):
             return self.model.__tablename__
 
     @staticmethod
-    def get_primary_keys(instance) -> dict:
+    def get_primary_keys(instance):
         """
             Returns the primary keys
 
@@ -114,7 +110,7 @@ class ModelWrapper(object):
     primary_keys.__doc__ = get_primary_keys.__func__.__doc__
 
     @staticmethod
-    def get_unique_keys(instance) -> dict:
+    def get_unique_keys(instance):
         """
             Returns the primary keys
 
@@ -134,7 +130,7 @@ class ModelWrapper(object):
     unique_keys.__doc__ = get_unique_keys.__func__.__doc__
 
     @staticmethod
-    def get_foreign_keys(instance) -> list:
+    def get_foreign_keys(instance):
         """
             Returns the foreign keys
 
@@ -155,7 +151,7 @@ class ModelWrapper(object):
     foreign_keys.__doc__ = get_foreign_keys.__func__.__doc__
 
     @staticmethod
-    def get_columns(instance) -> dict:
+    def get_columns(instance):
         """
             Returns the columns objects of the model
         """
@@ -172,7 +168,7 @@ class ModelWrapper(object):
     columns.__doc__ = get_columns.__func__.__doc__
 
     @staticmethod
-    def get_attributes(instance) -> dict:
+    def get_attributes(instance):
         """
             Returns the attributes of the model
         """
@@ -189,7 +185,7 @@ class ModelWrapper(object):
     attributes.__doc__ = get_attributes.__func__.__doc__
 
     @staticmethod
-    def get_relations(instance) -> dict:
+    def get_relations(instance):
         """
             Returns the relations objects of the model
         """
@@ -206,7 +202,7 @@ class ModelWrapper(object):
     relations.__doc__ = get_relations.__func__.__doc__
 
     @staticmethod
-    def get_hybrids(instance) -> list:
+    def get_hybrids(instance):
         """
             Returns the relations objects of the model
         """
@@ -221,7 +217,7 @@ class ModelWrapper(object):
                     if isinstance(field, hybrid_property)]
 
     @memoized_property
-    def hybrids(self) -> list:
+    def hybrids(self):
         """
         @see get_hybrids
         """
@@ -230,7 +226,7 @@ class ModelWrapper(object):
     hybrids.__doc__ = get_hybrids.__func__.__doc__
 
     @staticmethod
-    def get_proxies(instance) -> list:
+    def get_proxies(instance):
         """
             Returns the proxies objects of the model
 
@@ -260,11 +256,11 @@ class SessionedModelWrapper(ModelWrapper):
     """
 
     def __init__(self, model, session):
-        super().__init__(model)
+        super(SessionedModelWrapper, self).__init__(model)
         self.session = session
 
     @staticmethod
-    def _apply_kwargs(instance: Query, **kwargs) -> Query:
+    def _apply_kwargs(instance, **kwargs):
         for expression in kwargs.pop('filters', []):
             if _is_ordering_expression(expression):
                 instance = instance.order_by(expression)
@@ -288,7 +284,7 @@ class SessionedModelWrapper(ModelWrapper):
         instance = flimit(instance)
         return instance
 
-    def one(self, filters: list=(), **kwargs) -> object:
+    def one(self, filters=[], **kwargs):
         """
             Gets one instance of the model filtered by filters
 
@@ -303,7 +299,7 @@ class SessionedModelWrapper(ModelWrapper):
 
         return SessionedModelWrapper._apply_kwargs(instance, filters=filters, **kwargs).one()
 
-    def all(self, filters: list=(), **kwargs) -> list:
+    def all(self, filters=[], **kwargs):
         """
             Gets all instances of the query instance
 
@@ -319,7 +315,7 @@ class SessionedModelWrapper(ModelWrapper):
 
         return SessionedModelWrapper._apply_kwargs(instance, filters=filters, **kwargs).all()
 
-    def update(self, values: dict, filters: list=(), **kwargs) -> int:
+    def update(self, values, filters=[], **kwargs):
         """
             Updates all instances of the model filtered by filters
 
@@ -336,7 +332,7 @@ class SessionedModelWrapper(ModelWrapper):
 
         return SessionedModelWrapper._apply_kwargs(instance, filters=filters, **kwargs).update(values)
 
-    def delete(self, filters: list=(), **kwargs) -> int:
+    def delete(self, filters=[], **kwargs):
         """
             Delete all instances of the model filtered by filters
 
@@ -353,7 +349,7 @@ class SessionedModelWrapper(ModelWrapper):
 
         return SessionedModelWrapper._apply_kwargs(instance, filters=filters, **kwargs).delete()
 
-    def count(self, filters: list=(), **kwargs) -> int:
+    def count(self, filters=[], **kwargs):
         """
             Gets the instance count
 
@@ -367,7 +363,7 @@ class SessionedModelWrapper(ModelWrapper):
 
         return SessionedModelWrapper._apply_kwargs(instance, filters=filters, **kwargs).order_by(False).count()
 
-    def get(self, *pargs) -> object:
+    def get(self, *pargs):
         """
             Gets one instance of the model based on primary_keys
 


### PR DESCRIPTION
Unified library with support for both 2.7 and 3.3

Using the future library I was able to leave the bare super calls as well as handle the moves in urllib. The main removal was for type annotations as I could not find a good way to make that compatible.

This does meet the request from issue #4 

Feel free to reject the pull if you feel that type annotations are needed for the project.
